### PR TITLE
fix: powertarget was outside valid range

### DIFF
--- a/blueprints/automation/21energy_heater_control/thermal_curve_blueprint.yaml
+++ b/blueprints/automation/21energy_heater_control/thermal_curve_blueprint.yaml
@@ -72,4 +72,4 @@ action:
             target:
               entity_id: !input device_entity
             data:
-              value: "{{ level }}"
+              value: "{{ level+1 }}"


### PR DESCRIPTION
The powertarget setted by the level variable was out of range (0 - 4). The allowed range is 1 - 5.